### PR TITLE
Fix finding the correct program files directory on 17.0+

### DIFF
--- a/msbuild.js
+++ b/msbuild.js
@@ -133,7 +133,11 @@ msbuild.prototype.getMSBuildPath = function(os,processor,version){
 		BuildTools: 'BuildTools'
 	};
 	
-	programFilesDir = process.env['programfiles(x86)'] || process.env.PROGRAMFILES;
+	if (parseFloat(version) >= 17.0)
+		programFilesDir = process.env.PROGRAMFILES;
+	else
+		programFilesDir = process.env['programfiles(x86)'] || process.env.PROGRAMFILES;
+
 	console.log('Found "programFiles" dir = ' + programFilesDir);
 
 	// For the msbuild 15+ versions, use the appropriate VS2017, VS2019 & VS2022 directories


### PR DESCRIPTION
Was hitting an issue where the programFilesDir was set to the (x86) directory instead of the normal 64 bit directory.

Not sure if there is a better solution but this was a quick fix to force it to look in the correct directory on 17.0 or later.